### PR TITLE
Small fixes

### DIFF
--- a/src/nomad_parser_magres/parsers/__init__.py
+++ b/src/nomad_parser_magres/parsers/__init__.py
@@ -17,5 +17,5 @@ nomad_parser_magres_plugin = MagresParserEntryPoint(
     level=1,
     parser_as_interface=False,  # in order to use `child_archives` and auto workflows
     mainfile_contents_re=r'\$magres-abinitio-v(\d\.)+',
-    # mainfile_name_re='^.*magres',
+    mainfile_name_re=r'.+\.magres',
 )

--- a/src/nomad_parser_magres/parsers/parser.py
+++ b/src/nomad_parser_magres/parsers/parser.py
@@ -8,11 +8,10 @@ if TYPE_CHECKING:
     from nomad_simulations.schema_packages.model_system import Cell
     from structlog.stdlib import BoundLogger
 
-from nomad.app.v1.models.models import MetadataRequired
+from nomad.parsing import MatchingParser
 from nomad.config import config
 from nomad.datamodel.metainfo.workflow import Link, TaskReference
 from nomad.parsing.file_parser import Quantity, TextParser
-from nomad.search import search
 from nomad.units import ureg
 from nomad.utils import extract_section
 from nomad_simulations.schema_packages.atoms_state import AtomsState
@@ -180,7 +179,7 @@ class MagresFileParser(TextParser):
         ]
 
 
-class MagresParser:
+class MagresParser(MatchingParser):
     def __init__(self, *args, **kwargs):
         super().__init__()
         self.magres_file_parser = MagresFileParser()
@@ -710,6 +709,8 @@ class MagresParser:
         filepath_stripped = self.mainfile.split('raw/')[-1]
         metadata = []
         try:
+            from nomad.search import search
+            from nomad.app.v1.models.models import MetadataRequired
             upload_id = self.archive.metadata.upload_id
             search_ids = search(
                 owner='visible',

--- a/src/nomad_parser_magres/parsers/parser.py
+++ b/src/nomad_parser_magres/parsers/parser.py
@@ -180,26 +180,26 @@ class MagresFileParser(TextParser):
 
 
 class MagresParser(MatchingParser):
-    def __init__(self, *args, **kwargs):
-        super().__init__()
-        self.magres_file_parser = MagresFileParser()
+    # def __init__(self, *args, **kwargs):
+    #     super().__init__()
+    magres_file_parser = MagresFileParser()
 
-        self._xc_functional_map = {
-            'LDA': ['LDA_C_PZ', 'LDA_X_PZ'],
-            'PW91': ['GGA_C_PW91', 'GGA_X_PW91'],
-            'PBE': ['GGA_C_PBE', 'GGA_X_PBE'],
-            'RPBE': ['GGA_X_RPBE'],
-            'WC': ['GGA_C_PBE_GGA_X_WC'],
-            'PBESOL': ['GGA_X_RPBE'],
-            'BLYP': ['GGA_C_LYP', 'LDA_X_B88'],
-            'B3LYP': ['HYB_GGA_XC_B3LYP5'],
-            'HF': ['HF_X'],
-            'HF-LDA': ['HF_X_LDA_C_PW'],
-            'PBE0': ['HYB_GGA_XC_PBEH'],
-            'HSE03': ['HYB_GGA_XC_HSE03'],
-            'HSE06': ['HYB_GGA_XC_HSE06'],
-            'RSCAN': ['MGGA_X_RSCAN', 'MGGA_C_RSCAN'],
-        }
+    _xc_functional_map = {
+        'LDA': ['LDA_C_PZ', 'LDA_X_PZ'],
+        'PW91': ['GGA_C_PW91', 'GGA_X_PW91'],
+        'PBE': ['GGA_C_PBE', 'GGA_X_PBE'],
+        'RPBE': ['GGA_X_RPBE'],
+        'WC': ['GGA_C_PBE_GGA_X_WC'],
+        'PBESOL': ['GGA_X_RPBE'],
+        'BLYP': ['GGA_C_LYP', 'LDA_X_B88'],
+        'B3LYP': ['HYB_GGA_XC_B3LYP5'],
+        'HF': ['HF_X'],
+        'HF-LDA': ['HF_X_LDA_C_PW'],
+        'PBE0': ['HYB_GGA_XC_PBEH'],
+        'HSE03': ['HYB_GGA_XC_HSE03'],
+        'HSE06': ['HYB_GGA_XC_HSE06'],
+        'RSCAN': ['MGGA_X_RSCAN', 'MGGA_C_RSCAN'],
+    }
 
     def _check_units_magres(self, logger: 'BoundLogger') -> None:
         """

--- a/src/nomad_parser_magres/parsers/parser.py
+++ b/src/nomad_parser_magres/parsers/parser.py
@@ -8,9 +8,9 @@ if TYPE_CHECKING:
     from nomad_simulations.schema_packages.model_system import Cell
     from structlog.stdlib import BoundLogger
 
-from nomad.parsing import MatchingParser
 from nomad.config import config
 from nomad.datamodel.metainfo.workflow import Link, TaskReference
+from nomad.parsing import MatchingParser
 from nomad.parsing.file_parser import Quantity, TextParser
 from nomad.units import ureg
 from nomad.utils import extract_section
@@ -106,7 +106,7 @@ class MagresFileParser(TextParser):
                         ),
                         Quantity(
                             'kpoint_mp_offset',
-                            rf'calc\_kpoint\_mp\_offset({re_float*3})$',
+                            rf'calc\_kpoint\_mp\_offset({re_float * 3})$',
                         ),
                     ]
                 ),
@@ -116,11 +116,11 @@ class MagresFileParser(TextParser):
                 r'([\[\<]*atoms[\>\]]*[\s\S]+?)(?:[\[\<]*\/atoms[\>\]]*)',
                 sub_parser=TextParser(
                     quantities=[
-                        Quantity('lattice', rf'lattice({re_float*9})'),
+                        Quantity('lattice', rf'lattice({re_float * 9})'),
                         Quantity('symmetry', r'symmetry *([\w\-\+\,]+)', repeats=True),
                         Quantity(
                             'atom',
-                            rf'atom *([a-zA-Z]+) *[a-zA-Z\d]* *([\d]+) *({re_float*3})',
+                            rf'atom *([a-zA-Z]+) *[a-zA-Z\d]* *([\d]+) *({re_float * 3})',
                             repeats=True,
                         ),
                     ]
@@ -132,47 +132,47 @@ class MagresFileParser(TextParser):
                 sub_parser=TextParser(
                     quantities=[
                         Quantity(
-                            'ms', rf'ms *(\w+) *(\d+)({re_float*9})', repeats=True
+                            'ms', rf'ms *(\w+) *(\d+)({re_float * 9})', repeats=True
                         ),
                         Quantity(
-                            'efg', rf'efg *(\w+) *(\d+)({re_float*9})', repeats=True
+                            'efg', rf'efg *(\w+) *(\d+)({re_float * 9})', repeats=True
                         ),
                         Quantity(
                             'efg_local',
-                            rf'efg_local *(\w+) *(\d+)({re_float*9})',
+                            rf'efg_local *(\w+) *(\d+)({re_float * 9})',
                             repeats=True,
                         ),
                         Quantity(
                             'efg_nonlocal',
-                            rf'efg_nonlocal *(\w+) *(\d+)({re_float*9})',
+                            rf'efg_nonlocal *(\w+) *(\d+)({re_float * 9})',
                             repeats=True,
                         ),
                         Quantity(
                             'isc',
-                            rf'isc *(\w+) *(\d+) *(\w+) *(\d+)({re_float*9})',
+                            rf'isc *(\w+) *(\d+) *(\w+) *(\d+)({re_float * 9})',
                             repeats=True,
                         ),
                         Quantity(
                             'isc_fc',
-                            rf'isc_fc *(\w+) *(\d+) *(\w+) *(\d+)({re_float*9})',
+                            rf'isc_fc *(\w+) *(\d+) *(\w+) *(\d+)({re_float * 9})',
                             repeats=True,
                         ),
                         Quantity(
                             'isc_orbital_p',
-                            rf'isc_orbital_p *(\w+) *(\d+) *(\w+) *(\d+)({re_float*9})',
+                            rf'isc_orbital_p *(\w+) *(\d+) *(\w+) *(\d+)({re_float * 9})',
                             repeats=True,
                         ),
                         Quantity(
                             'isc_orbital_d',
-                            rf'isc_orbital_d *(\w+) *(\d+) *(\w+) *(\d+)({re_float*9})',
+                            rf'isc_orbital_d *(\w+) *(\d+) *(\w+) *(\d+)({re_float * 9})',
                             repeats=True,
                         ),
                         Quantity(
                             'isc_spin',
-                            rf'isc_spin *(\w+) *(\d+) *(\w+) *(\d+)({re_float*9})',
+                            rf'isc_spin *(\w+) *(\d+) *(\w+) *(\d+)({re_float * 9})',
                             repeats=True,
                         ),
-                        Quantity('sus', rf'sus *({re_float*9})', repeats=True),
+                        Quantity('sus', rf'sus *({re_float * 9})', repeats=True),
                     ]
                 ),
             ),
@@ -709,8 +709,9 @@ class MagresParser(MatchingParser):
         filepath_stripped = self.mainfile.split('raw/')[-1]
         metadata = []
         try:
-            from nomad.search import search
             from nomad.app.v1.models.models import MetadataRequired
+            from nomad.search import search
+
             upload_id = self.archive.metadata.upload_id
             search_ids = search(
                 owner='visible',

--- a/src/nomad_parser_magres/parsers/parser.py
+++ b/src/nomad_parser_magres/parsers/parser.py
@@ -180,26 +180,26 @@ class MagresFileParser(TextParser):
 
 
 class MagresParser(MatchingParser):
-    # def __init__(self, *args, **kwargs):
-    #     super().__init__()
-    magres_file_parser = MagresFileParser()
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.magres_file_parser = MagresFileParser()
 
-    _xc_functional_map = {
-        'LDA': ['LDA_C_PZ', 'LDA_X_PZ'],
-        'PW91': ['GGA_C_PW91', 'GGA_X_PW91'],
-        'PBE': ['GGA_C_PBE', 'GGA_X_PBE'],
-        'RPBE': ['GGA_X_RPBE'],
-        'WC': ['GGA_C_PBE_GGA_X_WC'],
-        'PBESOL': ['GGA_X_RPBE'],
-        'BLYP': ['GGA_C_LYP', 'LDA_X_B88'],
-        'B3LYP': ['HYB_GGA_XC_B3LYP5'],
-        'HF': ['HF_X'],
-        'HF-LDA': ['HF_X_LDA_C_PW'],
-        'PBE0': ['HYB_GGA_XC_PBEH'],
-        'HSE03': ['HYB_GGA_XC_HSE03'],
-        'HSE06': ['HYB_GGA_XC_HSE06'],
-        'RSCAN': ['MGGA_X_RSCAN', 'MGGA_C_RSCAN'],
-    }
+        self._xc_functional_map = {
+            'LDA': ['LDA_C_PZ', 'LDA_X_PZ'],
+            'PW91': ['GGA_C_PW91', 'GGA_X_PW91'],
+            'PBE': ['GGA_C_PBE', 'GGA_X_PBE'],
+            'RPBE': ['GGA_X_RPBE'],
+            'WC': ['GGA_C_PBE_GGA_X_WC'],
+            'PBESOL': ['GGA_X_RPBE'],
+            'BLYP': ['GGA_C_LYP', 'LDA_X_B88'],
+            'B3LYP': ['HYB_GGA_XC_B3LYP5'],
+            'HF': ['HF_X'],
+            'HF-LDA': ['HF_X_LDA_C_PW'],
+            'PBE0': ['HYB_GGA_XC_PBEH'],
+            'HSE03': ['HYB_GGA_XC_HSE03'],
+            'HSE06': ['HYB_GGA_XC_HSE06'],
+            'RSCAN': ['MGGA_X_RSCAN', 'MGGA_C_RSCAN'],
+        }
 
     def _check_units_magres(self, logger: 'BoundLogger') -> None:
         """

--- a/src/nomad_parser_magres/schema_packages/ccpnc_metadata.py
+++ b/src/nomad_parser_magres/schema_packages/ccpnc_metadata.py
@@ -15,7 +15,7 @@ class MaterialProperties(ArchiveSection):
 
     chemical_name_tokens = Quantity(
         type=str,
-        shape=["*"],
+        shape=['*'],
         description="""
         Free-text chemical name, but tokenised to take individual words in the name to assist in wildcard searches.
         """,
@@ -24,7 +24,7 @@ class MaterialProperties(ArchiveSection):
     formula = Quantity(
         # type=[(str, int)],  # better to use JSON type
         type=JSON,
-        shape=["*"],
+        shape=['*'],
         description="""
         Dictionary containing the species (chemical symbol of an element in the material) as keys and
         number of atoms of that element in the material as their value.
@@ -33,7 +33,7 @@ class MaterialProperties(ArchiveSection):
 
     stoichiometry = Quantity(
         type=JSON,
-        shape=["*"],
+        shape=['*'],
         description="""
         Reduced proportion of materials details.
         """,
@@ -41,7 +41,7 @@ class MaterialProperties(ArchiveSection):
 
     elements_ratios = Quantity(
         type=np.float64,
-        shape=["*"],
+        shape=['*'],
         description="""
         Ratio of constituent elements (each element is a number between 0 and 1).
         """,
@@ -61,7 +61,7 @@ class MaterialProperties(ArchiveSection):
 class ORCID(ArchiveSection):
     orcid_id = Quantity(
         type=JSON,
-        shape=["*"],
+        shape=['*'],
         description="""
         Dictionary containing the ORCID IDs of the author (keys) and uploader (values) profiles.
         """,


### PR DESCRIPTION
Hi @Sathya-S3,

I installed your plugin and found that it was not running properly for several reasons:

- circular import of `from nomad.search import search` and `from nomad.app.v1.models.models import MetadataRequired`
- missing `is_mainfile` method caused by missing MatchingParser inheritance 
- wrong behaviour of the parser that was matching all the uploaded files because the init method of the MagresParser class was missing args in the super call.

I also strengthened the matching conditions asking for a ".magres" mainfile name. 

If you think these changes are fine for you, you can test them and eventually merge them